### PR TITLE
Bump Go version from 1.23.2 -> 1.23.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/artefactual-sdps/preprocessing-base
 
-go 1.23.2
+go 1.23.5
 
 require (
 	github.com/artefactual-sdps/temporal-activities v0.0.0-20250116225551-b0b1966e3e19


### PR DESCRIPTION
Fixes https://pkg.go.dev/vuln/GO-2025-3373.